### PR TITLE
use proper version of jwt lib

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "require": {
     "php": ">=7.1.0",
-    "lcobucci/jwt": "^4.1"
+    "lcobucci/jwt": "4.1.*"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
This change needed to be done because fatal errors were caused by the use of short keys. This version does not check the private key's actual length so the error doesn't happen.